### PR TITLE
fix: remove stage 4 transform to prefer preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "autoprefixer": "~9.1.5",
     "@babel/core": "~7.1.2",
     "@babel/plugin-proposal-class-properties": "~7.1.0",
-    "@babel/plugin-proposal-object-rest-spread": "~7.0.0",
     "@babel/preset-env": "~7.1.0",
     "@babel/preset-react": "~7.0.0",
     "@babel/plugin-transform-runtime": "~7.1.0",

--- a/test-app/.babelrc.js
+++ b/test-app/.babelrc.js
@@ -6,14 +6,16 @@ module.exports = {
           '@babel/preset-env',
           {
             modules: false,
-            targets: { browsers: ['>0.25%', 'not ie 11', 'not op_mini all'] },
+            targets: {
+              Chrome: '65',
+              Firefox: '60',
+            },
           },
         ],
         '@babel/preset-react',
       ],
       plugins: [
         'react-hot-loader/babel',
-        '@babel/plugin-proposal-object-rest-spread',
         '@babel/plugin-proposal-class-properties',
         '@babel/plugin-transform-runtime', // Needed for generators and babel-helpers
       ],
@@ -30,7 +32,6 @@ module.exports = {
         '@babel/preset-react',
       ],
       plugins: [
-        '@babel/plugin-proposal-object-rest-spread',
         '@babel/plugin-proposal-class-properties',
         '@babel/plugin-transform-runtime', // Needed for generators and babel-helpers
       ],

--- a/test-app/src/dux/app/index.js
+++ b/test-app/src/dux/app/index.js
@@ -1,0 +1,17 @@
+const defaultState = {
+  rad: true,
+}
+
+const reducer = (state = defaultState, { type, payload }) => {
+  switch (type) {
+    case 'RAD':
+      return {
+        ...state,
+        rad: payload.rad,
+      }
+    default:
+      return state
+  }
+}
+
+export default reducer

--- a/test-app/src/dux/reducers.js
+++ b/test-app/src/dux/reducers.js
@@ -1,3 +1,4 @@
-export default function(state = {} /* , action */) {
-  return state
-}
+import { combineReducers } from 'redux'
+import app from './app'
+
+export default combineReducers({ app })


### PR DESCRIPTION
Object spread is now a stage 4 proposal, so this transform is managed by the `preset-env` package 🎉