### PR TITLE
Fix: Remove styled-components plugin from project bundled dependencies 🔧

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@svgr/webpack": "4.3.2",
     "autoprefixer": "9.6.1",
     "babel-loader": "8.0.6",
-    "babel-plugin-styled-components": "1.10.6",
     "chalk": "2.4.2",
     "clean-webpack-plugin": "3.0.0",
     "compression-webpack-plugin": "3.0.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -28,6 +28,7 @@
     "svg-symbol-sprite-loader": "3.2.0"
   },
   "devDependencies": {
+    "babel-plugin-styled-components": "1.10.6",
     "@crystal-ball/prettier-base": "1.4.0",
     "eslint-config-eloquence": "12.4.0",
     "jest": "24.9.0"


### PR DESCRIPTION
Styled components are not expected to be used in every project and including the babel plugin causes npm warnings when projects aren't using styled components.