### PR TITLE
Release: V6 - Zeit-tastic 🔮✨

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY ./package.json /usr/src/react-application-prototype/node_modules/@crystal-b
 
 
 # Copy serve config for prod build testing with `serve`
-RUN echo "{ \"public\": \"dist\" }" >> ./serve.json
+RUN echo "{ \"public\": \"public\" }" >> ./serve.json
 
 # Run Build
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ const paths = {
 - Output directory cleaning
 - Injected `PUBLIC_PATH` for routing
 - `DEVTOOL` environment variable will override source maps
+- Import paths case is verified to ensure Linux and MacOS compatability
 
 ### Relative import alias
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm i -D @crystal-ball/webpack-base
 **3. Add configuration files**
 
 Add configuration files for webpack and Babel to the project root. The
-[crystal-ball/react-application-prototype][] is a complete working reference
+[@crystal-ball/react-application-prototype][] is a complete working reference
 application using this package. Projects require a:
 
 - `.babelrc.js`
@@ -91,8 +91,6 @@ projects that use the default project directory structure:
 
 ```
 project
-├─ / public
-│  └─  favicon.ico
 ├─ / src
 │  └─ / api
 │  └─ / components
@@ -102,9 +100,12 @@ project
 │  └─ / styles
 │  │  └─ / dev
 │  │  └─ / prod
-│  └─ / lib
+│  └─ / utils
 │  ├─  index.html
-│  └─  index.js
+│  ├─  index.js
+│  └─  index.scss
+├─ / static
+│  └─  favicon.ico
 ├─  .babelrc.js
 ├─  .eslintrc.js
 └─  webpack.config.js
@@ -112,17 +113,18 @@ project
 
 ### Directories
 
-- **public** - The public folder can be used as an escape hatch for including
-  assets that are not directly imported in the project code. The contents are
-  copied to the output directory during builds.
+- **src** - Project source code root directory. Imports relative to this
+  directory can be made with the `@` alias.
 - **src/media/icons** - The SVG symbol sprite loader will sprite any SVG icons
   imported from this directory.
-- **src/styles** - SASS files in this directory can be imported with the @ alias
-  from anywhere in the project. The `dev` and `prod` directories are passed as
-  `importPaths` to `node-sass` according to the build env.
-- **src/index.js** - The application entry file.
-- **api**, **components**, **dux** and **lib** directories are not required,
-  only suggested as a convenient setup.
+- **src/styles** - SCSS files in this directory can be imported with the `@`
+  alias from anywhere in the project. Files in the dev and prod directory will
+  be resolved based on the `NODE_ENV`
+- **src/api**, **src/components**, **src/dux** and **src/utils** - Suggested but
+  not required directory structure for organizing application code by domain
+- **static** - The static folder can be used as an escape hatch for including
+  assets that are not directly imported in the project code. The contents are
+  copied to the output directory during builds.
 
 ## 📝 Configuration API
 
@@ -168,49 +170,50 @@ const { configs } = webpackBase{
 ```javascript
 const paths = {
   /**
+   * Project root directory that is used by webpack (eg to handle resolutions).
+   * webpack base attempts to automatically set the project context, but it
+   * can help fix resolution errors to specify it.
+   * @default /
+   */
+  context,
+  /**
+   * SVG files imported from these directories will be loaded+sprited using the
+   * `SVGSymbolSprite` package.
+   * @default ['/src/media/icons']
+   */
+  iconSpriteIncludes,
+  /**
+   * JS files imported from these directories will be loaded using the JS loader.
+   * @default ['/src']
+   */
+  jsLoaderIncludes,
+  /**
+   * Build assets are emitted to this directory.
+   * @default /public
+   */
+  output,
+  /**
+   * SCSS files in these directories can be imported in other SCSS files using
+   * relative imports. (Useful for importing shared variables or mixins inside
+   * component style files)
+   * @default ['/src/styles', '/src/styles/[dev|prod]]
+   */
+  sassIncludes,
+  /**
+   * Application source files directory. The directory is added to the webpack
+   * alias config as `@` to allow using imports relative to the source
+   * directory.
+   * @default /src
+   */
+  src,
+  /**
    * Application public static files directory. This directory is copied to the
    * build without manipulation by the `CopyWebpackPlugin` and provides an
    * escape hatch to include assets in a build without importing them in the
    * application source.
+   * @default /static
    */
-  appPublic, // ./public
-  /**
-   * Application source files directory. The directory is added to the webpack
-   * alias config as `@` to allow using imports relative to the source
-   * directory
-   */
-  appSrc, // ./src
-  /**
-   * Project root directory that is used by webpack (eg to handle resolutions).
-   * webpack base attempts to automatically set the project context, but it
-   * can help fix resolution errors to specify it.
-   */
-  context, // ./
-  /**
-   * Directories/files that will be loaded && sprited using the
-   * `SVGSymbolSprite` system.
-   */
-  iconSpritePaths, // [./src/media/icons]
-  /**
-   * Directories that will be loaded using the JS loader, is passed as the
-   * loader `include` property.
-   */
-  jsLoaderPaths, // [./src]
-  /**
-   * Directory that build assets are emitted to.
-   */
-  outputPath, // ./dist
-  /**
-   * The prefix appended to every URL created by the runtime or loaders. This
-   * enables serving an application with a CDN or server subdirectory.
-   */
-  publicPath, // '/'
-  /**
-   * Directories included in the SASS resolver. Resources in these directories
-   * will be available using relative imports. Useful for importing shared SASS
-   * resources inside component SASS definitions.
-   */
-  sassIncludePaths, // ['src/styles']
+  static,
 }
 ```
 
@@ -248,11 +251,11 @@ import SomeComponent from '@/components/SomeComponent'
 
 The following environment variables are injected by the build:
 
-| Constant      | Usage                                                                                   |
-| ------------- | --------------------------------------------------------------------------------------- |
-| `NODE_ENV`    | Defaults to match NODE_ENV, used by Babili to strip code in prod builds                 |
-| `DEBUG`       | Defaults to false, can be used for adding detailed logging in dev environment           |
-| `PUBLIC_PATH` | Set to `publicPath` configuration, useful for importing media and configuring CDN paths |
+| Constant      | Usage                                                                         |
+| ------------- | ----------------------------------------------------------------------------- |
+| `NODE_ENV`    | Defaults to match NODE_ENV, used by Babili to strip code in prod builds       |
+| `DEBUG`       | Defaults to false, can be used for adding detailed logging in dev environment |
+| `PUBLIC_PATH` | Defaults to '/', useful for importing media and configuring CDN paths         |
 
 Additional environment variables can be passed in an `envVars` option and they
 will be injected into the build
@@ -379,6 +382,6 @@ users of ESLint import plugin are able to parse these webpack configs.
 <!-- Links -->
 <!-- prettier-ignore-start -->
 [bundle]: https://github.com/samccone/bundle-buddy
-[crystal-ball/react-application-prototype]: https://github.com/crystal-ball/react-application-prototype
+[@crystal-ball/react-application-prototype]: https://github.com/crystal-ball/react-application-prototype
 [profile]: https://webpack.js.org/configuration/other-options/#profile
 <!-- prettier-ignore-end -->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,5 @@ services:
       - '5000:5000'
     volumes:
       # Mount source so we don't have to rebuild image on every file change
-      - './src:/usr/src/app/node_modules/@crystal-ball/webpack-base/src'
+      - './src:/usr/src/react-application-prototype/node_modules/@crystal-ball/webpack-base/src'
     command: /bin/sh

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "case-sensitive-paths-webpack-plugin": "2.2.0",
     "chalk": "2.4.2",
     "clean-webpack-plugin": "3.0.0",
-    "compression-webpack-plugin": "3.0.0",
     "copy-webpack-plugin": "5.0.4",
     "core-js": "3.2.1",
     "css-loader": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@svgr/webpack": "4.3.2",
     "autoprefixer": "9.6.1",
     "babel-loader": "8.0.6",
+    "case-sensitive-paths-webpack-plugin": "2.2.0",
     "chalk": "2.4.2",
     "clean-webpack-plugin": "3.0.0",
     "compression-webpack-plugin": "3.0.0",

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -205,6 +205,7 @@ Object {
   "resolve": Object {
     "alias": Object {
       "@": "/test/src",
+      "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
       ".js",
@@ -421,6 +422,7 @@ Object {
   "resolve": Object {
     "alias": Object {
       "@": "/test/src/renderer",
+      "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
       ".js",
@@ -649,6 +651,7 @@ Object {
   "resolve": Object {
     "alias": Object {
       "@": "/test/src/renderer",
+      "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
       ".js",
@@ -880,6 +883,7 @@ Object {
   "resolve": Object {
     "alias": Object {
       "@": "/test/src",
+      "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
       ".js",

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -4,7 +4,7 @@ exports[`webpack-base returns expected dev configs 1`] = `
 Object {
   "context": "/test",
   "devServer": Object {
-    "contentBase": "/test/public",
+    "contentBase": "/test/static",
     "historyApiFallback": true,
     "hot": true,
     "open": false,
@@ -115,7 +115,7 @@ Object {
   "output": Object {
     "filename": "static/js/[name].js",
     "hashDigestLength": 12,
-    "path": "/test/dist",
+    "path": "/test/public",
     "publicPath": "/",
   },
   "plugins": Array [
@@ -149,7 +149,7 @@ Object {
         "chunksSortMode": "auto",
         "compile": true,
         "excludeChunks": Array [],
-        "favicon": "/test/public/favicon.ico",
+        "favicon": "/test/static/favicon.ico",
         "filename": "index.html",
         "hash": false,
         "inject": true,
@@ -171,7 +171,7 @@ Object {
     CopyPlugin {
       "options": Object {},
       "patterns": Array [
-        "/test/public",
+        "/test/static",
       ],
     },
     HotModuleReplacementPlugin {
@@ -205,16 +205,11 @@ Object {
   "resolve": Object {
     "alias": Object {
       "@": "/test/src",
-      "warning": "/test/node_modules/warning",
     },
     "extensions": Array [
       ".js",
       ".jsx",
       ".json",
-    ],
-    "modules": Array [
-      "/test/src",
-      "node_modules",
     ],
   },
 }
@@ -224,7 +219,7 @@ exports[`webpack-base returns expected electron dev configs 1`] = `
 Object {
   "context": "/test",
   "devServer": Object {
-    "contentBase": "/test/public",
+    "contentBase": "/test/static",
     "historyApiFallback": true,
     "hot": true,
     "open": false,
@@ -370,7 +365,7 @@ Object {
         "chunksSortMode": "auto",
         "compile": true,
         "excludeChunks": Array [],
-        "favicon": "/test/public/favicon.ico",
+        "favicon": "/test/static/favicon.ico",
         "filename": "index.html",
         "hash": false,
         "inject": false,
@@ -392,7 +387,7 @@ Object {
     CopyPlugin {
       "options": Object {},
       "patterns": Array [
-        "/test/public",
+        "/test/static",
       ],
     },
     HotModuleReplacementPlugin {
@@ -426,16 +421,11 @@ Object {
   "resolve": Object {
     "alias": Object {
       "@": "/test/src/renderer",
-      "warning": "/test/node_modules/warning",
     },
     "extensions": Array [
       ".js",
       ".jsx",
       ".json",
-    ],
-    "modules": Array [
-      "/test/src/renderer",
-      "node_modules",
     ],
   },
   "target": "electron-renderer",
@@ -594,7 +584,7 @@ Object {
         "chunksSortMode": "auto",
         "compile": true,
         "excludeChunks": Array [],
-        "favicon": "/test/public/favicon.ico",
+        "favicon": "/test/static/favicon.ico",
         "filename": "index.html",
         "hash": false,
         "inject": false,
@@ -616,7 +606,7 @@ Object {
     CopyPlugin {
       "options": Object {},
       "patterns": Array [
-        "/test/public",
+        "/test/static",
       ],
     },
     NamedModulesPlugin {
@@ -655,36 +645,15 @@ Object {
         "filename": "static/css/[name].css",
       },
     },
-    CompressionPlugin {
-      "options": Object {
-        "algorithm": [Function],
-        "cache": false,
-        "compressionOptions": Object {
-          "level": 9,
-        },
-        "deleteOriginalAssets": false,
-        "exclude": undefined,
-        "filename": "[path][query]",
-        "include": undefined,
-        "minRatio": 0.8,
-        "test": undefined,
-        "threshold": 0,
-      },
-    },
   ],
   "resolve": Object {
     "alias": Object {
       "@": "/test/src/renderer",
-      "warning": "/test/node_modules/warning",
     },
     "extensions": Array [
       ".js",
       ".jsx",
       ".json",
-    ],
-    "modules": Array [
-      "/test/src/renderer",
-      "node_modules",
     ],
   },
   "stats": Object {
@@ -806,7 +775,7 @@ Object {
   "output": Object {
     "filename": "static/js/[name].[chunkhash].js",
     "hashDigestLength": 12,
-    "path": "/test/dist",
+    "path": "/test/public",
     "publicPath": "/",
   },
   "performance": Object {
@@ -846,7 +815,7 @@ Object {
         "chunksSortMode": "auto",
         "compile": true,
         "excludeChunks": Array [],
-        "favicon": "/test/public/favicon.ico",
+        "favicon": "/test/static/favicon.ico",
         "filename": "index.html",
         "hash": false,
         "inject": true,
@@ -868,7 +837,7 @@ Object {
     CopyPlugin {
       "options": Object {},
       "patterns": Array [
-        "/test/public",
+        "/test/static",
       ],
     },
     NamedModulesPlugin {
@@ -907,36 +876,15 @@ Object {
         "filename": "static/css/[name].[chunkhash].css",
       },
     },
-    CompressionPlugin {
-      "options": Object {
-        "algorithm": [Function],
-        "cache": false,
-        "compressionOptions": Object {
-          "level": 9,
-        },
-        "deleteOriginalAssets": false,
-        "exclude": undefined,
-        "filename": "[path][query]",
-        "include": undefined,
-        "minRatio": 0.8,
-        "test": undefined,
-        "threshold": 0,
-      },
-    },
   ],
   "resolve": Object {
     "alias": Object {
       "@": "/test/src",
-      "warning": "/test/node_modules/warning",
     },
     "extensions": Array [
       ".js",
       ".jsx",
       ".json",
-    ],
-    "modules": Array [
-      "/test/src",
-      "node_modules",
     ],
   },
   "stats": Object {
@@ -1043,7 +991,7 @@ Object {
     "copyPlugin": CopyPlugin {
       "options": Object {},
       "patterns": Array [
-        "/test/public",
+        "/test/static",
       ],
     },
     "environmentPlugin": EnvironmentPlugin {
@@ -1090,7 +1038,7 @@ Object {
         "chunksSortMode": "auto",
         "compile": true,
         "excludeChunks": Array [],
-        "favicon": "/test/public/favicon.ico",
+        "favicon": "/test/static/favicon.ico",
         "filename": "index.html",
         "hash": false,
         "inject": true,

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -119,6 +119,12 @@ Object {
     "publicPath": "/",
   },
   "plugins": Array [
+    CaseSensitivePathsPlugin {
+      "fsOperations": 0,
+      "options": Object {},
+      "pathCache": Object {},
+      "primed": false,
+    },
     ProgressBarPlugin {
       "options": Object {
         "callback": [Function],
@@ -334,6 +340,12 @@ Object {
     "publicPath": "/",
   },
   "plugins": Array [
+    CaseSensitivePathsPlugin {
+      "fsOperations": 0,
+      "options": Object {},
+      "pathCache": Object {},
+      "primed": false,
+    },
     ProgressBarPlugin {
       "options": Object {
         "callback": [Function],
@@ -552,6 +564,12 @@ Object {
     "maxEntrypointSize": 500000,
   },
   "plugins": Array [
+    CaseSensitivePathsPlugin {
+      "fsOperations": 0,
+      "options": Object {},
+      "pathCache": Object {},
+      "primed": false,
+    },
     ProgressBarPlugin {
       "options": Object {
         "callback": [Function],
@@ -798,6 +816,12 @@ Object {
     "maxEntrypointSize": 500000,
   },
   "plugins": Array [
+    CaseSensitivePathsPlugin {
+      "fsOperations": 0,
+      "options": Object {},
+      "pathCache": Object {},
+      "primed": false,
+    },
     ProgressBarPlugin {
       "options": Object {
         "callback": [Function],
@@ -1010,6 +1034,12 @@ Object {
     },
   },
   "plugins": Object {
+    "caseSensitivePathsPlugin": CaseSensitivePathsPlugin {
+      "fsOperations": 0,
+      "options": Object {},
+      "pathCache": Object {},
+      "primed": false,
+    },
     "copyPlugin": CopyPlugin {
       "options": Object {},
       "patterns": Array [

--- a/src/common-configs.js
+++ b/src/common-configs.js
@@ -1,32 +1,33 @@
 'use strict'
 
-const { resolve } = require('path')
+// const { resolve } = require('path')
 
 /** The common configurations are used across environments */
-module.exports = ({
-  chunkHash,
-  flags: { mode },
-  paths: { appEntry, appSrc, context, outputPath, publicPath },
-}) => ({
+module.exports = ({ chunkHash, publicPath, flags, paths }) => ({
   // webpack v4+ automatic environment optimization switch
   // https://webpack.js.org/concepts/mode/
-  mode,
+  mode: flags.mode,
 
   // Explicitly set the build context for resolving entry points and loaders
   // https://webpack.js.org/configuration/entry-context/#context
-  context,
+  context: paths.context,
 
   // Default to a single entry and let webpack automatically split and name bundles
   // https://webpack.js.org/configuration/entry-context/#entry
-  entry: appEntry,
+  entry: paths.appIndex,
 
   // Default to webpack /dist output with hashed filenames in prod builds for long
   // term caching, see README for docs on config effects
   // https://webpack.js.org/configuration/output/
   output: {
-    path: outputPath,
+    path: paths.output,
     filename: `static/js/[name]${chunkHash}.js`,
-    publicPath,
+    // The publicPath value is prefixed to every URL created by the runtime or
+    // loaders. The default is '' which means resources from nested routes have
+    // incorrect paths, eg: 'some/application/route/static/js/main.js
+    // The default config set here ensures that requests are absolute, eg:
+    // '/static/js/main.js'
+    publicPath: publicPath || '/',
     // Configures the lengths of [hash] and [chunkhash] globally
     hashDigestLength: 12,
   },
@@ -35,21 +36,12 @@ module.exports = ({
   // https://webpack.js.org/configuration/resolve/
   resolve: {
     extensions: ['.js', '.jsx', '.json'],
-    // Tell webpack what directories should be searched when resolving modules.
-    // Including `appSrc` allows for importing modules relative to /src directory!
-    // DEPRECATED: importing relative to appSrc is deprecated, projects should use
-    // the @ alias to import relative to /src.
-    modules: [appSrc, 'node_modules'],
-    // Alias can be used to point imports to specific modules, include empty object
-    // to allow direct assignment in consuming packages
+    // Alias can be used to point imports to specific modules, include empty
+    // object to allow direct assignment in consuming packages
     alias: {
       // Alias @ to the src/ directory for explicit imports relative to src directory, eg:
       // `import SomeComponent from '@/components/universal'`
-      '@': appSrc,
-      // Short term fix to resolve duplicate versions of warning being imported
-      // when using react-router,
-      // see: https://github.com/ReactTraining/history/issues/601
-      warning: resolve(context, 'node_modules/warning'),
+      '@': paths.src,
     },
   },
 

--- a/src/common-configs.js
+++ b/src/common-configs.js
@@ -85,6 +85,7 @@ module.exports = ({
   // Common plugins
   // ---------------------------------------------------------------------------
   plugins: [
+    'caseSensitivePlugin',
     'progressBarPlugin',
     'environmentPlugin',
     'htmlPlugin',

--- a/src/common-configs.js
+++ b/src/common-configs.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// const { resolve } = require('path')
+const path = require('path')
 
 /** The common configurations are used across environments */
 module.exports = ({ chunkHash, publicPath, flags, paths }) => ({
@@ -42,6 +42,8 @@ module.exports = ({ chunkHash, publicPath, flags, paths }) => ({
       // Alias @ to the src/ directory for explicit imports relative to src directory, eg:
       // `import SomeComponent from '@/components/universal'`
       '@': paths.src,
+      // Ensure that only one @babel/runtime is bundled into application
+      '@babel/runtime': path.resolve(paths.context, 'node_modules/@babel/runtime'),
     },
   },
 

--- a/src/common-configs.js
+++ b/src/common-configs.js
@@ -85,7 +85,7 @@ module.exports = ({
   // Common plugins
   // ---------------------------------------------------------------------------
   plugins: [
-    'caseSensitivePlugin',
+    'caseSensitivePathsPlugin',
     'progressBarPlugin',
     'environmentPlugin',
     'htmlPlugin',

--- a/src/development-configs.js
+++ b/src/development-configs.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /** Development environment specfic configurations */
-module.exports = ({ devServer, paths: { appPublic } }) => ({
+module.exports = ({ devServer, paths }) => ({
   // Set DEVTOOL to 'eval' to see generated code, but show useful original source
   // for development workflows. Additional considerations:
   // https://github.com/facebookincubator/create-react-app/issues/343#issuecomment-237241875
@@ -27,7 +27,7 @@ module.exports = ({ devServer, paths: { appPublic } }) => ({
 
     // Serve static file from the public file (only required for files not
     // imported into project)
-    contentBase: appPublic,
+    contentBase: paths.static,
     // Serve index.html for all unmatched routes
     historyApiFallback: true,
     // Enable hot module replacement feature

--- a/src/generate-loaders.js
+++ b/src/generate-loaders.js
@@ -8,14 +8,11 @@ const postCSSCustomProperties = require('postcss-custom-properties')
  * Returns the set of loaders for the passed opts including:
  * babel, sass, svgSprite, svgComponent, file, raw
  */
-module.exports = ({
-  flags: { production },
-  paths: { iconSpritePaths, jsLoaderPaths, sassIncludePaths },
-}) => ({
+module.exports = ({ flags, paths }) => ({
   // --- 🎉 JS Loader
   jsLoader: overrides => ({
     test: /\.jsx?$/,
-    include: jsLoaderPaths,
+    include: paths.jsLoaderIncludes,
     /**
      * ## Using Eslint Loader
      * The `eslint-loader` will run imported modules through eslint first and
@@ -33,7 +30,7 @@ module.exports = ({
 
   // --- 😍 Styles Loader
   sassLoader: overrides =>
-    production
+    flags.production
       ? {
           // ℹ️ Prod styles uses SCSS+CSS loader chain to import, includes
           // PostCSS+Autoprefixer for browser compatability, and extracts final styles
@@ -64,7 +61,7 @@ module.exports = ({
               // for importing app theme variables and mixins into component styles
               options: {
                 sassOptions: {
-                  includePaths: sassIncludePaths,
+                  includePaths: paths.sassIncludes,
                 },
               },
             },
@@ -93,7 +90,7 @@ module.exports = ({
               // for importing app theme variables and mixins into component styles
               options: {
                 sassOptions: {
-                  includePaths: sassIncludePaths,
+                  includePaths: paths.sassIncludes,
                 },
               },
             },
@@ -105,7 +102,7 @@ module.exports = ({
   // Create an svg sprite with any icons imported into app
   svgSpriteLoader: overrides => ({
     test: /\.svg$/,
-    include: iconSpritePaths,
+    include: paths.iconSpriteIncludes,
     use: [{ loader: 'svg-symbol-sprite-loader' }],
     ...overrides,
   }),
@@ -115,7 +112,7 @@ module.exports = ({
   svgComponentLoader: overrides => ({
     test: /\.svg$/,
     // Make sure that we don't try to use with icons for svg sprite
-    exclude: iconSpritePaths,
+    exclude: paths.iconSpriteIncludes,
     use: [{ loader: '@svgr/webpack' }],
     ...overrides,
   }),

--- a/src/generate-plugins.js
+++ b/src/generate-plugins.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin')
@@ -29,6 +30,11 @@ module.exports = ({
   flags: { electron },
   paths: { appPublic, htmlTemplate, publicPath },
 }) => ({
+  // --------------------------------------------------------
+  // ✅ Path validation
+  // Ensure that import paths are case sensitive to ensure Linux/MacOS  compatability
+  caseSensitivePathsPlugin: new CaseSensitivePathsPlugin(),
+
   // --- 📦 Build Prep
   // Wipe output folder before the build
   cleanPlugin: new CleanWebpackPlugin(),

--- a/src/generate-plugins.js
+++ b/src/generate-plugins.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
-const CompressionPlugin = require('compression-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin')
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin')
@@ -23,13 +22,7 @@ const {
  * hotModuleReplacement, html, miniCSSExtract, namedModules, progressBar,
  * svgSymbolSprite
  */
-module.exports = ({
-  chunkHash,
-  devServer,
-  envVars,
-  flags: { electron },
-  paths: { appPublic, htmlTemplate, publicPath },
-}) => ({
+module.exports = ({ chunkHash, devServer, envVars, flags, publicPath, paths }) => ({
   // --------------------------------------------------------
   // ✅ Path validation
   // Ensure that import paths are case sensitive to ensure Linux/MacOS  compatability
@@ -39,17 +32,10 @@ module.exports = ({
   // Wipe output folder before the build
   cleanPlugin: new CleanWebpackPlugin(),
 
-  // --- ⬇️ Compress
-  // Gzip build assets, do not include deleteOriginalAssets or it will delete the
-  // gzipped assets that have the same name
-  compressPlugin: new CompressionPlugin({
-    filename: '[path][query]',
-  }),
-
   // --- 🖨 File copying
   // Copy public directory to build directory, this is an escape hatch for assets
   // needed that are not imported into build
-  copyPlugin: new CopyWebpackPlugin([appPublic]),
+  copyPlugin: new CopyWebpackPlugin([paths.static]),
 
   // --- ✅ Validations + Optimizations
   // Check for duplicate versions of the same package, ie React 15 && React 16
@@ -63,7 +49,7 @@ module.exports = ({
   // ℹ️ Values passed to EnvironmentPlugin are defaults
   environmentPlugin: new EnvironmentPlugin({
     DEBUG: false,
-    PUBLIC_PATH: publicPath, // useful for routing and media from /public dir
+    PUBLIC_PATH: publicPath || '/', // useful for routing and media from /public dir
     ...envVars,
   }),
 
@@ -88,10 +74,10 @@ module.exports = ({
   // --- 📦 HTML index generator
   // Generates index.html with injected script/style resources paths
   htmlPlugin: new HtmlWebpackPlugin({
-    favicon: `${appPublic}/favicon.ico`,
-    inject: !electron,
+    favicon: `${paths.static}/favicon.ico`,
+    inject: !flags.electron,
     minify: false,
-    template: htmlTemplate,
+    template: paths.htmlTemplate,
   }),
 
   // --- 😍 Styles extractions

--- a/src/production-configs.js
+++ b/src/production-configs.js
@@ -33,6 +33,5 @@ module.exports = () => ({
     'cleanPlugin',
     'duplicatePackageCheckerPlugin',
     'miniCSSExtractPlugin',
-    'compressPlugin',
   ],
 })


### PR DESCRIPTION
Version 6 updates the package to work with Zeit Now without additional configuration and includes
cleanup of deprecated v5 features.

Closes #27

BREAKING CHANGE: The compression plugin has been removed (Zeit provides Brotli compression out of
box), The output directory is now `public` to match Zeit defaults, the public directory is now
`static` and the configuration path names have been cleaned up (see README for new names)