### PR TITLE
New: Remove @ webpack alias management 💥

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -233,7 +233,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
@@ -481,7 +480,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src/renderer",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
@@ -768,7 +766,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src/renderer",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
@@ -1058,7 +1055,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
@@ -1309,7 +1305,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [

--- a/src/common-configs.js
+++ b/src/common-configs.js
@@ -39,9 +39,6 @@ module.exports = ({ chunkHash, publicPath, flags, paths }) => ({
     // Alias can be used to point imports to specific modules, include empty
     // object to allow direct assignment in consuming packages
     alias: {
-      // Alias @ to the src/ directory for explicit imports relative to src directory, eg:
-      // `import SomeComponent from '@/components/universal'`
-      '@': paths.src,
       // Ensure that only one @babel/runtime is bundled into application
       '@babel/runtime': path.resolve(paths.context, 'node_modules/@babel/runtime'),
     },

--- a/src/decorate-options.js
+++ b/src/decorate-options.js
@@ -30,7 +30,6 @@ module.exports = function decorateOptions({ paths = {}, target, ...rest } = {}) 
       context,
       output: join(context, 'public'),
       static: join(context, 'static'),
-      src,
       appIndex: join(src, 'index.js'),
       htmlTemplate: join(src, 'index.html'),
       iconSpriteIncludes: [join(src, 'media/icons')],


### PR DESCRIPTION
Aliases should be handled with babel-plugin-transform-import aliases. All Crystal Ball projects will
use Babel going forward and this allows Node projects to use src convenience aliases like webpack
projects.

BREAKING CHANGE: Aliases must be transformed with `babel-plugin-transform-import-aliases`