### PR TITLE
New: Remove @ webpack alias management 💥

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.15.0 as base
+FROM node:12.16.0 as base
 LABEL maintainer="hedgecock.d@gmail.com"
 
 WORKDIR /usr/src

--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ project
 
 ### Directories
 
-- **src** - Project source code root directory. Imports relative to this
-  directory can be made with the `@` alias.
+- **src** - Project source code root directory.
 - **src/media/icons** - The SVG symbol sprite loader will sprite any SVG icons
   imported from this directory.
 - **src/styles** - SCSS files in this directory can be imported with the `@`
@@ -223,9 +222,8 @@ const paths = {
    */
   sassIncludes,
   /**
-   * Application source files directory. The directory is added to the webpack
-   * alias config as `@` to allow using imports relative to the source
-   * directory.
+   * Application source files directory. This directory is used as a base for
+   * the icon includes path.
    * @default /src
    */
   src,
@@ -256,21 +254,6 @@ const paths = {
 - Import paths case is verified to ensure Linux and MacOS compatability
 - Production CSS+JS assets are minified
 - Application logo is used to generate and inject favicon resources in build
-
-### Relative import alias
-
-Relative imports can be made from the `src` file using an `@`:
-
-```javascript
-// In any JS file
-import SomeComponent from '@/components/SomeComponent'
-```
-
-```scss
-// In any SASS file, note the ~ is required to flag to SASS resolver that this
-// is a relative import
-@import '~@/styles/theme';
-```
 
 ### Environment variable injection
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@svgr/webpack": "5.1.0",
     "autoprefixer": "9.7.4",
     "babel-loader": "8.0.6",
+    "babel-plugin-transform-import-aliases": "1.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "case-sensitive-paths-webpack-plugin": "2.3.0",
     "chalk": "3.0.0",
@@ -67,8 +68,8 @@
     "sass-loader": "8.0.2",
     "style-loader": "1.1.3",
     "svg-symbol-sprite-loader": "4.0.0",
-    "webpack": "4.41.5",
-    "webpack-cli": "3.3.10",
+    "webpack": "4.41.6",
+    "webpack-cli": "3.3.11",
     "webpack-dev-server": "3.10.3",
     "webpack-merge": "4.2.2"
   },
@@ -78,9 +79,9 @@
     "@crystal-ball/semantic-release-base": "2.13.0",
     "@percy/cypress": "2.3.0",
     "@types/jest": "25.1.2",
-    "cypress": "4.0.1",
-    "eslint-config-eloquence": "13.1.0",
-    "husky": "4.2.1",
+    "cypress": "4.0.2",
+    "eslint-config-eloquence": "13.2.1",
+    "husky": "4.2.3",
     "jest": "25.1.0"
   },
   "config": {

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -233,7 +233,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
@@ -481,7 +480,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src/renderer",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
@@ -768,7 +766,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src/renderer",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
@@ -1058,7 +1055,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [
@@ -1309,7 +1305,6 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "@": "/test/src",
       "@babel/runtime": "/test/node_modules/@babel/runtime",
     },
     "extensions": Array [

--- a/src/common-configs.js
+++ b/src/common-configs.js
@@ -39,9 +39,6 @@ module.exports = ({ chunkHash, publicPath, flags, paths }) => ({
     // Alias can be used to point imports to specific modules, include empty
     // object to allow direct assignment in consuming packages
     alias: {
-      // Alias @ to the src/ directory for explicit imports relative to src directory, eg:
-      // `import SomeComponent from '@/components/universal'`
-      '@': paths.src,
       // Ensure that only one @babel/runtime is bundled into application
       '@babel/runtime': path.resolve(paths.context, 'node_modules/@babel/runtime'),
     },

--- a/src/decorate-options.js
+++ b/src/decorate-options.js
@@ -30,7 +30,6 @@ module.exports = function decorateOptions({ paths = {}, target, ...rest } = {}) 
       context,
       output: join(context, 'public'),
       static: join(context, 'static'),
-      src,
       appIndex: join(src, 'index.js'),
       htmlTemplate: join(src, 'index.html'),
       iconSpriteIncludes: [join(src, 'media/icons')],


### PR DESCRIPTION
Aliases should be handled with babel-plugin-transform-import aliases. All Crystal Ball projects will
use Babel going forward and this allows Node projects to use src convenience aliases like webpack
projects.

BREAKING CHANGE: Aliases must be transformed with `babel-plugin-transform-import-aliases`